### PR TITLE
Resolve Issue With LibSass DLLs in App_Data

### DIFF
--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -426,10 +426,6 @@
     <Content Include="App_Data\Themes\default\templates\quote-request.liquid">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="App_Data\x64\LibSass.x64.dll" />
-    <Content Include="App_Data\x64\libsassnet.dll" />
-    <Content Include="App_Data\x86\LibSass.x86.dll" />
-    <Content Include="App_Data\x86\libsassnet.dll" />
     <Content Include="App_Data\Themes\default\assets\js\account\account-password-change.tpl.liquid" />
     <Content Include="App_Data\Themes\default\assets\js\account\account-profile-update.tpl.liquid" />
     <Content Include="App_Data\Themes\default\assets\js\account\account-orders.tpl.liquid">
@@ -458,6 +454,10 @@
       <SubType>Designer</SubType>
     </Content>
     <None Include="AutoRestClients\!readme.txt" />
+    <AdditionalFiles Include="App_Data\x86\LibSass.x86.dll" />
+    <AdditionalFiles Include="App_Data\x86\libsassnet.dll" />
+    <AdditionalFiles Include="App_Data\x64\LibSass.x64.dll" />
+    <AdditionalFiles Include="App_Data\x64\libsassnet.dll" />
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
     <Content Include="Web.config">

--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -769,13 +769,6 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <Target Name="DeleteLibSassFilesFromBin" AfterTargets="Build">
-    <ItemGroup>
-      <LibSassFiles Include="$(WebProjectOutputDir)\bin\libsassnet.dll" />
-      <LibSassFiles Include="$(WebProjectOutputDir)\bin\LibSass.x64.dll" />
-    </ItemGroup>
-    <Delete Files="@(LibSassFiles)" />
-  </Target>
   <!-- Transform Web.config -->
   <UsingTask TaskName="TransformXml" AssemblyFile="$(VSToolsPath)\Web\Microsoft.Web.Publishing.Tasks.dll" Condition="Exists('$(VSToolsPath)\Web\Microsoft.Web.Publishing.Tasks.dll')" />
   <PropertyGroup>

--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -454,10 +454,10 @@
       <SubType>Designer</SubType>
     </Content>
     <None Include="AutoRestClients\!readme.txt" />
-    <AdditionalFiles Include="App_Data\x86\LibSass.x86.dll" />
-    <AdditionalFiles Include="App_Data\x86\libsassnet.dll" />
-    <AdditionalFiles Include="App_Data\x64\LibSass.x64.dll" />
-    <AdditionalFiles Include="App_Data\x64\libsassnet.dll" />
+    <Resource Include="App_Data\x86\LibSass.x86.dll" />
+    <Resource Include="App_Data\x86\libsassnet.dll" />
+    <Resource Include="App_Data\x64\LibSass.x64.dll" />
+    <Resource Include="App_Data\x64\libsassnet.dll" />
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
     <Content Include="Web.config">


### PR DESCRIPTION
Web deploy was failing as the delete target was executing after the packaging. Looked into it a little more and using the "AdditionalFile" type seems to prevent the DLLs from getting copied and then makes it so the target to delete them is not needed.