### PR TITLE
VP-3273: Get rid of forcing sync operation

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -63,18 +63,8 @@ jobs:
 
     - name: Wait for environment is up
       shell: pwsh
-      env:
-        ARGOCD_SERVER: cd.govirto.com
-        ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
       timeout-minutes: 5
       run: |
-        cd ${{ github.workspace }}
-
-        $latestVersion = (Invoke-WebRequest -Uri "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | ConvertFrom-Json).tag_name
-        Invoke-WebRequest -Uri "https://github.com/argoproj/argo-cd/releases/download/$($latestVersion)/argocd-linux-amd64" -OutFile argocd
-        chmod +x argocd
-        ./argocd app sync webstore-dev-app --grpc-web --async
-        
         do {
           Start-Sleep -s 15
 


### PR DESCRIPTION
### Problem
The Deploy workflow required ARGO CD token.

### Solution
Get rid of forcing sync operation since sync happens on push to the VirtoCommerce/vc-deploy-apps repository.

### Proposed of changes
N/A

### Additional context (optional)
N/A