### PR TITLE
VP-3582: Add outlines property to product for promotion evaluation

### DIFF
--- a/VirtoCommerce.Storefront.Model/Catalog/Product.cs
+++ b/VirtoCommerce.Storefront.Model/Catalog/Product.cs
@@ -72,6 +72,10 @@ namespace VirtoCommerce.Storefront.Model.Catalog
         /// All parent categories ids concatenated with "/". E.g. (1/21/344)
         /// </summary>
         public string Outline { get; set; }
+        ///// <summary>
+        /// All outlines of product
+        /// </summary>
+        public List<string> Outlines { get; set; }
         /// <summary>
         /// Slug path e.g /camcorders/blue-win-camera
         /// </summary>

--- a/VirtoCommerce.Storefront.Model/Catalog/Product.cs
+++ b/VirtoCommerce.Storefront.Model/Catalog/Product.cs
@@ -75,7 +75,7 @@ namespace VirtoCommerce.Storefront.Model.Catalog
         ///// <summary>
         /// All outlines of product
         /// </summary>
-        public List<string> Outlines { get; set; }
+        public string Outlines { get; set; }
         /// <summary>
         /// Slug path e.g /camcorders/blue-win-camera
         /// </summary>

--- a/VirtoCommerce.Storefront.Model/Catalog/Product.cs
+++ b/VirtoCommerce.Storefront.Model/Catalog/Product.cs
@@ -72,8 +72,8 @@ namespace VirtoCommerce.Storefront.Model.Catalog
         /// All parent categories ids concatenated with "/". E.g. (1/21/344)
         /// </summary>
         public string Outline { get; set; }
-        ///// <summary>
-        /// All outlines of product
+        /// <summary>
+        /// All relative product outlines for the given catalog
         /// </summary>
         public string Outlines { get; set; }
         /// <summary>

--- a/VirtoCommerce.Storefront/Domain/Cart/CartConverter.cs
+++ b/VirtoCommerce.Storefront/Domain/Cart/CartConverter.cs
@@ -801,7 +801,7 @@ namespace VirtoCommerce.Storefront.Domain
                 Quantity = lineItem.Quantity,
                 InStockQuantity = lineItem.InStockQuantity,
                 // VP-3582: We need to pass all product outlines as 1 string to use them for promotion evaluation
-                Outline = string.Join(";", lineItem.Product.Outlines),
+                Outline = lineItem.Product.Outlines,
                 Variations = null // TODO
             };
 

--- a/VirtoCommerce.Storefront/Domain/Cart/CartConverter.cs
+++ b/VirtoCommerce.Storefront/Domain/Cart/CartConverter.cs
@@ -800,7 +800,8 @@ namespace VirtoCommerce.Storefront.Domain
                 Price = (double)lineItem.SalePrice.Amount,
                 Quantity = lineItem.Quantity,
                 InStockQuantity = lineItem.InStockQuantity,
-                Outline = lineItem.Product.Outline,
+                // VP-3582: We need to pass all product outlines as 1 string to use them for promotion evaluation
+                Outline = string.Join(";", lineItem.Product.Outlines),
                 Variations = null // TODO
             };
 

--- a/VirtoCommerce.Storefront/Domain/Catalog/CatalogConverter.cs
+++ b/VirtoCommerce.Storefront/Domain/Catalog/CatalogConverter.cs
@@ -340,6 +340,8 @@ namespace VirtoCommerce.Storefront.Domain
                 Length = (decimal?)productDto.Length,
                 Sku = productDto.Code,
                 Outline = productDto.Outlines.GetOutlinePath(store.Catalog),
+                // VP-3582: We need to store all product outlines to use them for promotion evaluation
+                Outlines = productDto.Outlines?.Where(x => x != null).Select(x => x.ToPathString()).ToList() ?? new List<string>(),
                 SeoPath = productDto.Outlines.GetSeoPath(store, currentLanguage, null),
             };
             result.Url = "/" + (result.SeoPath ?? "product/" + result.Id);
@@ -434,7 +436,8 @@ namespace VirtoCommerce.Storefront.Domain
             {
                 CatalogId = product.CatalogId,
                 CategoryId = product.CategoryId,
-                Outline = product.Outline,
+                // VP-3582: We need to pass all product outlines as 1 string to use them for promotion evaluation
+                Outline = string.Join(";", product.Outlines),
                 Code = product.Sku,
                 ProductId = product.Id,
                 Quantity = 1,

--- a/VirtoCommerce.Storefront/Domain/Catalog/CatalogConverter.cs
+++ b/VirtoCommerce.Storefront/Domain/Catalog/CatalogConverter.cs
@@ -341,7 +341,7 @@ namespace VirtoCommerce.Storefront.Domain
                 Sku = productDto.Code,
                 Outline = productDto.Outlines.GetOutlinePath(store.Catalog),
                 // VP-3582: We need to store all product outlines to use them for promotion evaluation
-                Outlines = productDto.Outlines?.Where(x => x != null).Select(x => x.ToPathString()).ToList() ?? new List<string>(),
+                Outlines = productDto.Outlines.GetOutlinePaths(store.Catalog),
                 SeoPath = productDto.Outlines.GetSeoPath(store, currentLanguage, null),
             };
             result.Url = "/" + (result.SeoPath ?? "product/" + result.Id);
@@ -437,7 +437,7 @@ namespace VirtoCommerce.Storefront.Domain
                 CatalogId = product.CatalogId,
                 CategoryId = product.CategoryId,
                 // VP-3582: We need to pass all product outlines as 1 string to use them for promotion evaluation
-                Outline = string.Join(";", product.Outlines),
+                Outline = product.Outlines,
                 Code = product.Sku,
                 ProductId = product.Id,
                 Quantity = 1,

--- a/VirtoCommerce.Storefront/Extensions/OutlineExtensions.cs
+++ b/VirtoCommerce.Storefront/Extensions/OutlineExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using VirtoCommerce.Storefront.AutoRestClients.CartModuleApi.Models;
 using VirtoCommerce.Storefront.Model.Catalog;
 using VirtoCommerce.Tools;
 using catalogDto = VirtoCommerce.Storefront.AutoRestClients.CatalogModuleApi.Models;
@@ -39,6 +40,11 @@ namespace VirtoCommerce.Storefront.Common
             }
 
             return result;
+        }
+
+        public static string ToPathString(this catalogDto.Outline outline)
+        {
+            return outline.Items == null ? null : string.Join("/", outline.Items.Select(x => x.Id));
         }
     }
 }

--- a/VirtoCommerce.Storefront/Extensions/OutlineExtensions.cs
+++ b/VirtoCommerce.Storefront/Extensions/OutlineExtensions.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using VirtoCommerce.Storefront.AutoRestClients.CartModuleApi.Models;
 using VirtoCommerce.Storefront.Model.Catalog;
 using VirtoCommerce.Tools;
 using catalogDto = VirtoCommerce.Storefront.AutoRestClients.CatalogModuleApi.Models;

--- a/VirtoCommerce.Storefront/Extensions/OutlineExtensions.cs
+++ b/VirtoCommerce.Storefront/Extensions/OutlineExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using VirtoCommerce.Storefront.AutoRestClients.CartModuleApi.Models;
 using VirtoCommerce.Storefront.Model.Catalog;
 using VirtoCommerce.Tools;
 using catalogDto = VirtoCommerce.Storefront.AutoRestClients.CatalogModuleApi.Models;

--- a/VirtoCommerce.Storefront/Extensions/OutlineExtensions.cs
+++ b/VirtoCommerce.Storefront/Extensions/OutlineExtensions.cs
@@ -41,7 +41,17 @@ namespace VirtoCommerce.Storefront.Common
             return result;
         }
 
-        public static string ToPathString(this catalogDto.Outline outline)
+        public static string GetOutlinePaths(this IEnumerable<catalogDto.Outline> outlines, string catalogId)
+        {
+            var result = string.Empty;
+            var convertedOutlines = outlines?.Select(o => o.JsonConvert<toolsDto.Outline>());
+            var catalogOutlines = convertedOutlines?.Where(o => o.Items.Any(i => i.SeoObjectType == "Catalog" && i.Id == catalogId));
+            var outlinesList = catalogOutlines?.Where(x => x != null).Select(x => x.ToPathString()).ToList() ?? new List<string>();
+            result = string.Join(";", outlinesList);
+            return result;
+        }
+
+        public static string ToPathString(this toolsDto.Outline outline)
         {
             return outline.Items == null ? null : string.Join("/", outline.Items.Select(x => x.Id));
         }


### PR DESCRIPTION
### Problem
Marketing promotions don’t work as expected, because the wrong one outline for product is chosen.

### Solution
In DynamicExpressionsModule we have support for multiple outlines, so just need to pass string that contains multiple outlines with separator 

### Proposed of changes
Add new Product propetry - Outlines, that contains all outlines of product with separator and then pass it to ProductPromoEntry

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
