### PR TITLE
VP-4155: Use Get image version action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,16 +3,29 @@ name: CI
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
+  workflow_dispatch:
   push:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'build/**'
+      - 'README.md'
+      - 'LICENSE'
     branches: [ master, dev ]
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'build/**'
+      - 'README.md'
+      - 'LICENSE'
     branches: [ master, dev ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 
-  unit-tests:
-    name: Unit Tests
+  sonar-analyze:
+    name: Sonar Analyze
     # The type of runner that the job will run on
     runs-on: windows-latest
     env:
@@ -25,7 +38,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install VirtoCommerce.GlobalTool
-      run: dotnet tool install --global VirtoCommerce.GlobalTool --version 1.0.0
+      run: dotnet tool install --global VirtoCommerce.GlobalTool
 
     - name: Install dotnet-sonarscanner
       run: dotnet tool install --global dotnet-sonarscanner
@@ -62,17 +75,20 @@ jobs:
 
   build-package:
     name: Build Package
+    outputs:
+        taggedVersion: ${{ steps.image.outputs.taggedVersion }}
+    
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
-    - name: Get Image Tag
-      uses: VirtoCommerce/vc-github-actions/get-image-tag@v2
+    - name: Get Image Version
+      uses: VirtoCommerce/vc-github-actions/get-image-version@dev
       id: image
 
     - name: Install VirtoCommerce.GlobalTool
-      run: dotnet tool install --global VirtoCommerce.GlobalTool --version 1.0.0
+      run: dotnet tool install --global VirtoCommerce.GlobalTool
 
     - name: Build Package
       run: vc-build Compress -skip Test
@@ -81,7 +97,7 @@ jobs:
       shell: pwsh
       run: |
         Invoke-WebRequest -Uri https://raw.githubusercontent.com/VirtoCommerce/vc-docker/master/linux/storefront/Dockerfile -OutFile artifacts/Dockerfile
-        docker build artifacts --build-arg SOURCE=. --tag "docker.pkg.github.com/$('${{ github.repository }}'.ToLower())/storefront:${{ steps.image.outputs.tag }}"
+        docker build artifacts --build-arg SOURCE=. --tag "docker.pkg.github.com/$('${{ github.repository }}'.ToLower())/storefront:${{ steps.image.outputs.taggedVersion }}"
 
     - name: Docker Login
       uses: azure/docker-login@v1
@@ -93,13 +109,13 @@ jobs:
     - name: Push Docker Image to GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker push "docker.pkg.github.com/$REPOSITORY/storefront:${{ steps.image.outputs.tag }}"
+        docker push "docker.pkg.github.com/$REPOSITORY/storefront:${{ steps.image.outputs.taggedVersion }}"
 
   publish:
     name: Publish image
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    needs: [build-package, unit-tests]
+    needs: [build-package, sonar-analyze]
     steps:
     - uses: actions/checkout@v2
 
@@ -110,14 +126,10 @@ jobs:
         username: $GITHUB_ACTOR
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get Image Tag
-      uses: VirtoCommerce/vc-github-actions/get-image-tag@v2
-      id: image
-
     - name: Pull Docker Image from GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker pull "docker.pkg.github.com/$REPOSITORY/storefront:${{ steps.image.outputs.tag }}"
+        docker pull "docker.pkg.github.com/$REPOSITORY/storefront:${{ needs.build-package.outputs.taggedVersion }}"
 
     - name: Push Docker Image to docker.pkg.github.com
       shell: pwsh
@@ -136,7 +148,7 @@ jobs:
 
         $DOCKER_TAG = $DOCKER_TAG.Replace('/', '_')
         
-        docker tag "$($REPOSITORY):${{ steps.image.outputs.tag }}" "$($REPOSITORY):$($DOCKER_TAG)"
+        docker tag "$($REPOSITORY):${{ needs.build-package.outputs.taggedVersion }}" "$($REPOSITORY):$($DOCKER_TAG)"
         docker push "$($REPOSITORY):$($DOCKER_TAG)"
         echo "::set-env name=BUILD_STATE::successful"
 
@@ -149,7 +161,7 @@ jobs:
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         DOCKER_TAG='dev-linux-experimental'
         if [ '${{ github.ref }}' = 'refs/heads/master' ]; then DOCKER_TAG=linux-experimental; fi
-        docker tag docker.pkg.github.com/$REPOSITORY/storefront:${{ steps.image.outputs.tag }} ${{ secrets.DOCKER_USERNAME }}/storefront:$DOCKER_TAG
+        docker tag docker.pkg.github.com/$REPOSITORY/storefront:${{ needs.build-package.outputs.taggedVersion }} ${{ secrets.DOCKER_USERNAME }}/storefront:$DOCKER_TAG
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
         docker push ${{ secrets.DOCKER_USERNAME }}/storefront:$DOCKER_TAG
         echo "::set-env name=BUILD_STATE::successful"


### PR DESCRIPTION
### Problem
Storefront image tags generate in old format `version-sha`

### Solution
Use `VirtoCommerce/vc-github-actions/get-image-version@dev` action

### Proposed of changes
Added path-ignore for push and PR events
Added CI workflow manual run
Added version number as output for `build-package` job
Renamed `unit-test` job to `sonar-analyze`
Used the latest VirtoCommerce.GlobalTool version