### PR TITLE
FIX Can not by product when inventory preorder quantity is null

### DIFF
--- a/VirtoCommerce.Storefront.Model/Catalog/Specifications/ProductIsAvailableSpecification.cs
+++ b/VirtoCommerce.Storefront.Model/Catalog/Specifications/ProductIsAvailableSpecification.cs
@@ -18,10 +18,10 @@ namespace VirtoCommerce.Storefront.Model.Catalog
             if (result && _product.TrackInventory)
             {
                 result = _product.Inventory != null &&
-                    _product.AvailableQuantity +
-                    (Convert.ToInt32(_product.Inventory.AllowPreorder) * _product.Inventory.PreorderQuantity) +
-                    (Convert.ToInt32(_product.Inventory.AllowBackorder) * _product.Inventory.BackorderQuantity)
-                    >= requestedQuantity;
+                         _product.AvailableQuantity +
+                         (Convert.ToInt32(_product.Inventory.AllowPreorder) * Convert.ToInt32(_product.Inventory.PreorderQuantity)) +
+                         (Convert.ToInt32(_product.Inventory.AllowBackorder) * Convert.ToInt32(_product.Inventory.BackorderQuantity))
+                         >= requestedQuantity;
             }
 
             return result;

--- a/VirtoCommerce.Storefront.Model/Catalog/Specifications/ProductIsInStockSpecification.cs
+++ b/VirtoCommerce.Storefront.Model/Catalog/Specifications/ProductIsInStockSpecification.cs
@@ -12,8 +12,8 @@ namespace VirtoCommerce.Storefront.Model.Catalog
             {
                 result = product.Inventory != null &&
                     product.AvailableQuantity +
-                    (Convert.ToInt32(product.Inventory.AllowPreorder) * product.Inventory.PreorderQuantity) +
-                    (Convert.ToInt32(product.Inventory.AllowBackorder) * product.Inventory.BackorderQuantity)
+                    (Convert.ToInt32(product.Inventory.AllowPreorder) * Convert.ToInt32(product.Inventory.PreorderQuantity)) +
+                    (Convert.ToInt32(product.Inventory.AllowBackorder) * Convert.ToInt32(product.Inventory.BackorderQuantity))
                     > 0;
             }
             return result;


### PR DESCRIPTION
### Problem
Can not by product when inventory preorder quantity is null

### Solution
convert null to 0

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
