### PR TITLE
VP-4168: Use Lax same site mode for XSRF-TOKEN cookie

### DIFF
--- a/VirtoCommerce.Storefront/Filters/AngularAntiforgeryCookieResultFilter.cs
+++ b/VirtoCommerce.Storefront/Filters/AngularAntiforgeryCookieResultFilter.cs
@@ -30,7 +30,7 @@ namespace VirtoCommerce.Storefront.Filters
             if (context.Result is ViewResult viewResult && statusCodeReExecuteFeature == null)
             {
                 var tokens = antiforgery.GetAndStoreTokens(context.HttpContext);
-                context.HttpContext.Response.Cookies.Append("XSRF-TOKEN", tokens.RequestToken, new CookieOptions() { HttpOnly = false, IsEssential = true });
+                context.HttpContext.Response.Cookies.Append("XSRF-TOKEN", tokens.RequestToken, new CookieOptions() { HttpOnly = false, IsEssential = true, SameSite = SameSiteMode.Lax });
             }
         }
 


### PR DESCRIPTION
### Problem
Starting from 84 version Chrome doesn't support cookies with SameSite=None without Secure flag

### Solution
Use Lax mode or always use HTTPS and set Secure flag

### Proposed of changes
Use Lax mode for CSRF token

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [ ] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
