### PR TITLE
VP-4420: Update storefront VirtoCommerce.Tools dependency to latest v3.4

### DIFF
--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.3.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.3.3" />
 	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.3.3" />
-    <PackageReference Include="VirtoCommerce.Tools" Version="3.0.2" />
+	<PackageReference Include="VirtoCommerce.Tools" Version="3.4.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 


### PR DESCRIPTION
This resolves the problem with absolute URI building on the Unix systems.
