### PR TITLE
VP-4415 Add additional checking of scheme into places with Uri.TryCreate() for absolute URI creating. 

### DIFF
--- a/VirtoCommerce.Storefront.Model/Stores/Store.cs
+++ b/VirtoCommerce.Storefront.Model/Stores/Store.cs
@@ -9,6 +9,8 @@ namespace VirtoCommerce.Storefront.Model.Stores
     /// </summary>
     public partial class Store : Entity, IHasSettings
     {
+        const string FILE_SCHEME = "file";
+
         public Store()
         {
             Languages = new List<Language>();
@@ -37,7 +39,7 @@ namespace VirtoCommerce.Storefront.Model.Stores
             get
             {
                 string result = null;
-                if (!string.IsNullOrEmpty(Url) && Uri.TryCreate(Url, UriKind.Absolute, out var url))
+                if (!string.IsNullOrEmpty(Url) && (Uri.TryCreate(Url, UriKind.Absolute, out var url) && url.Scheme != FILE_SCHEME))
                 {
                     result = url.Host;
                 }

--- a/VirtoCommerce.Storefront/Extensions/PathStringExtensions.cs
+++ b/VirtoCommerce.Storefront/Extensions/PathStringExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using VirtoCommerce.Storefront.Model;
@@ -8,6 +9,9 @@ namespace VirtoCommerce.Storefront.Extensions
 {
     public static class PathStringExtensions
     {
+
+        const string FILE_SCHEME = "file";
+
         private static Regex _storeLangeExpr = new Regex(@"^/\b\S+\b/[a-zA-Z]{2}-[a-zA-Z]{2}/");
         public static PathString GetStoreAndLangSegment(this PathString path)
         {
@@ -74,10 +78,10 @@ namespace VirtoCommerce.Storefront.Extensions
                 throw new ArgumentNullException(nameof(store));
             }
 
-            // Need to remove store path only if store has url
+            // Need to remove store path only if store has URL
             var storeUrl = !string.IsNullOrWhiteSpace(store.Url) ? store.Url : store.SecureUrl;
 
-            if (!string.IsNullOrWhiteSpace(storeUrl) && Uri.TryCreate(storeUrl, UriKind.Absolute, out var storeUri))
+            if (!string.IsNullOrWhiteSpace(storeUrl) && (Uri.TryCreate(storeUrl, UriKind.Absolute, out var storeUri) && storeUri.Scheme != FILE_SCHEME))
             {
                 var storeUriPath = storeUri.AbsolutePath.Trim('/');
 
@@ -95,7 +99,7 @@ namespace VirtoCommerce.Storefront.Extensions
         public static PathString ToAbsolutePath(this string path)
         {
             // Checks whether path is absolute path (starts with scheme), and extract local path if it is
-            if (Uri.TryCreate(path, UriKind.Absolute, out var absoluteUri))
+            if (Uri.TryCreate(path, UriKind.Absolute, out var absoluteUri) && absoluteUri.Scheme != FILE_SCHEME)
             {
                 return absoluteUri.AbsolutePath;
             }

--- a/VirtoCommerce.Storefront/Infrastructure/StorefrontUrlBuilder.cs
+++ b/VirtoCommerce.Storefront/Infrastructure/StorefrontUrlBuilder.cs
@@ -17,6 +17,8 @@ namespace VirtoCommerce.Storefront.Infrastructure
     /// </summary>
     public class StorefrontUrlBuilder : IStorefrontUrlBuilder
     {
+        const string FILE_SCHEME = "file";
+
         private readonly IUrlBuilder _urlBuilder;
         private readonly IWorkContextAccessor _workContextAccessor;
         private readonly IWebHostEnvironment _hostEnv;


### PR DESCRIPTION
On a Unix system Uri.TryCreate() behavior is not the same as on windows. It may cause problems. Therefore we need to check that scheme is not 'file' at absolute URI creating. 
https://github.com/dotnet/runtime/issues/22718