### PR TITLE
VP-2076: Preview of theme always open active theme

### DIFF
--- a/VirtoCommerce.Storefront/Domain/Stores/SelectCurrentStorePolicy.cs
+++ b/VirtoCommerce.Storefront/Domain/Stores/SelectCurrentStorePolicy.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.WebUtilities;
 using VirtoCommerce.Storefront.Model.Common;
 using VirtoCommerce.Storefront.Model.Stores;
 
@@ -35,21 +34,6 @@ namespace VirtoCommerce.Storefront.Domain
             }
 
             return result;
-        }
-
-        public static void ReplaceThemeForPreviewIfRequired(this Store store, HttpContext context)
-        {
-            if (context.Request.QueryString.HasValue)
-            {
-                var themePreview = QueryHelpers.ParseQuery(context.Request.QueryString.Value);
-
-                if (store != null && themePreview.ContainsKey("previewtheme"))
-                {
-                    var previewTheme = themePreview["previewtheme"].FirstOrDefault();
-
-                    store.ThemeName = previewTheme;
-                }
-            }
         }
     }
 }

--- a/VirtoCommerce.Storefront/Domain/Stores/SelectCurrentStorePolicy.cs
+++ b/VirtoCommerce.Storefront/Domain/Stores/SelectCurrentStorePolicy.cs
@@ -1,8 +1,9 @@
-using Microsoft.ApplicationInsights.AspNetCore.Extensions;
-using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
 using VirtoCommerce.Storefront.Model.Common;
 using VirtoCommerce.Storefront.Model.Stores;
 
@@ -19,9 +20,10 @@ namespace VirtoCommerce.Storefront.Domain
 
             //Try first find by store url (if it defined)
             var result = stores.FirstOrDefault(x => context.Request.Path.StartsWithSegments(new PathString("/" + x.Id)));
+
             if (result == null)
             {
-                result = stores.Where(x => x.IsStoreUrl(context.Request.GetUri())).FirstOrDefault();
+                result = stores.FirstOrDefault(x => x.IsStoreUrl(context.Request.GetUri()));
             }
             if (result == null && defaultStoreId != null)
             {
@@ -33,6 +35,21 @@ namespace VirtoCommerce.Storefront.Domain
             }
 
             return result;
+        }
+
+        public static void ReplaceThemeForPreviewIfRequired(this Store store, HttpContext context)
+        {
+            if (context.Request.QueryString.HasValue)
+            {
+                var themePreview = QueryHelpers.ParseQuery(context.Request.QueryString.Value);
+
+                if (store != null && themePreview.ContainsKey("previewtheme"))
+                {
+                    var previewTheme = themePreview["previewtheme"].FirstOrDefault();
+
+                    store.ThemeName = previewTheme;
+                }
+            }
         }
     }
 }

--- a/VirtoCommerce.Storefront/Domain/Stores/StoreWorkContextBuilderExtensions.cs
+++ b/VirtoCommerce.Storefront/Domain/Stores/StoreWorkContextBuilderExtensions.cs
@@ -1,9 +1,9 @@
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.Storefront.Infrastructure;
 using VirtoCommerce.Storefront.Model;
 using VirtoCommerce.Storefront.Model.Common;
@@ -22,6 +22,9 @@ namespace VirtoCommerce.Storefront.Domain
 
             builder.WorkContext.AllStores = stores.ToArray();
             var currentStore = builder.HttpContext.GetCurrentStore(stores, defaultStoreId);
+
+            currentStore.ReplaceThemeForPreviewIfRequired(builder.HttpContext);
+
             //Very important workaround. If left  Null or Empty as Url for default store with condition of multiple stores present, will be generated a relative url '/store_name/' instead of
             // '/' thats can  leads to invalid urls to default store and other issue with  <base href=""> that contains invalid relative  url
             if (defaultStoreId != null && string.IsNullOrEmpty(currentStore.Url) && currentStore.Id.EqualsInvariant(defaultStoreId))

--- a/VirtoCommerce.Storefront/Domain/Stores/StoreWorkContextBuilderExtensions.cs
+++ b/VirtoCommerce.Storefront/Domain/Stores/StoreWorkContextBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace VirtoCommerce.Storefront.Domain
             builder.WorkContext.AllStores = stores.ToArray();
             var currentStore = builder.HttpContext.GetCurrentStore(stores, defaultStoreId);
 
-            currentStore.ReplaceThemeForPreviewIfRequired(builder.HttpContext);
+            currentStore.ThemeName = builder.WorkContext.QueryString.Get("previewtheme") ?? currentStore.ThemeName;
 
             //Very important workaround. If left  Null or Empty as Url for default store with condition of multiple stores present, will be generated a relative url '/store_name/' instead of
             // '/' thats can  leads to invalid urls to default store and other issue with  <base href=""> that contains invalid relative  url


### PR DESCRIPTION
### Problem
There is no way to preview any other theme besides active.

### Solution
Theme should be able to preview using query string **?previewtheme=**

### Proposed of changes
Add query string interceptor and replace theme name by passed from **previewtheme** parameter.

### Additional context (optional)
![theme_preview](https://user-images.githubusercontent.com/15198683/91531041-6ca73c00-e90c-11ea-8dc2-59e4b3818f08.gif)

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
