### PR TITLE
VP-3949: Return payment method name instead of typeName

### DIFF
--- a/VirtoCommerce.Storefront/Domain/Stores/StoreService.cs
+++ b/VirtoCommerce.Storefront/Domain/Stores/StoreService.cs
@@ -80,7 +80,7 @@ namespace VirtoCommerce.Storefront.Domain
                     .Select(pm =>
                     {
                         var paymentMethod = pm.ToStorePaymentMethod(currency);
-                        paymentMethod.Name = pm.TypeName;
+                        paymentMethod.Name = pm.Name;
                         return paymentMethod;
                     }).ToArray();
             }


### PR DESCRIPTION
Fix for VP-3949: We need to show payment method name instead of typeName
![normalPaymentName](https://user-images.githubusercontent.com/22875828/91850227-7a86f500-ec5d-11ea-8225-3520c42f9e92.png)
