### PR TITLE
VP-5527: Propagate cancellation token messages to backplane

### DIFF
--- a/VirtoCommerce.LiquidThemeEngine/ThemeEngineCacheRegion.cs
+++ b/VirtoCommerce.LiquidThemeEngine/ThemeEngineCacheRegion.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
 namespace VirtoCommerce.LiquidThemeEngine

--- a/VirtoCommerce.Storefront.Model/Common/Caching/CacheCancellableTokensRegistry.cs
+++ b/VirtoCommerce.Storefront.Model/Common/Caching/CacheCancellableTokensRegistry.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Microsoft.Extensions.Primitives;
+
+namespace VirtoCommerce.Storefront.Model.Common.Caching
+{
+    /// <summary>
+    /// Stores all cancellation tokens that are associated for cached entries
+    /// </summary>
+    public static class CacheCancellableTokensRegistry
+    {
+        private static ConcurrentDictionary<string, CancellationTokenSource> _tokensDict = new ConcurrentDictionary<string, CancellationTokenSource>();
+        // Events are not used intentionally to restrict usage by multiple subscribers
+        public static Action<TokenCancelledEventArgs> OnTokenCancelled { get; set; }
+
+        public static IChangeToken CreateChangeToken(string tokenKey)
+        {
+            var tokenSource = _tokensDict.GetOrAdd(tokenKey, _ => new CancellationTokenSource());
+            return new CancellationChangeToken(tokenSource.Token);
+        }
+
+        public static bool TryCancelToken(string tokenKey, bool raiseEvent = true)
+        {
+            var result = _tokensDict.TryRemove(tokenKey, out var token);
+            if (result)
+            {
+                token.Cancel();
+                token.Dispose();
+            }
+            if (raiseEvent)
+            {
+                //Notify even if no token found for the key.
+                //It is important for cached data consistency when scale-out configuration is used, because other instances may contain cached entries with this key
+                TriggerOnCancel(tokenKey);
+            }
+            return result;
+        }
+
+        private static void TriggerOnCancel(string tokenKey)
+        {
+            OnTokenCancelled?.Invoke(new TokenCancelledEventArgs(tokenKey));
+        }
+    }
+}

--- a/VirtoCommerce.Storefront.Model/Common/Caching/GlobalCacheRegion.cs
+++ b/VirtoCommerce.Storefront.Model/Common/Caching/GlobalCacheRegion.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace VirtoCommerce.Storefront.Model.Common.Caching
 {
     public class GlobalCacheRegion : CancellableCacheRegion<GlobalCacheRegion>

--- a/VirtoCommerce.Storefront.Model/Common/Caching/TokenCancelledEventArgs.cs
+++ b/VirtoCommerce.Storefront.Model/Common/Caching/TokenCancelledEventArgs.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace VirtoCommerce.Storefront.Model.Common.Caching
+{
+    public sealed class TokenCancelledEventArgs : EventArgs
+    {
+        public TokenCancelledEventArgs(string tokenKey)
+        {
+            TokenKey = tokenKey;
+        }
+
+        public string TokenKey { get; }
+        public override string ToString()
+        {
+            return $"{TokenKey}";
+        }
+    }
+}

--- a/VirtoCommerce.Storefront/Caching/Redis/RedisCachingMessage.cs
+++ b/VirtoCommerce.Storefront/Caching/Redis/RedisCachingMessage.cs
@@ -1,7 +1,19 @@
+using System;
+using System.Linq;
+
 namespace VirtoCommerce.Storefront.Caching.Redis
 {
     internal class RedisCachingMessage
     {
+        public RedisCachingMessage()
+        {
+            Id = $"{Guid.NewGuid():N}";
+            CreationDate = DateTime.UtcNow;
+        }
+
+        public DateTime? CreationDate { get; set; }
+
+        public string InstanceId { get; set; }
         public string Id { get; set; }
 
         public object[] CacheKeys { get; set; }
@@ -9,5 +21,10 @@ namespace VirtoCommerce.Storefront.Caching.Redis
         public bool IsPrefix { get; set; }
 
         public bool IsToken { get; set; }
+
+        public override string ToString()
+        {
+            return $"{InstanceId}:{(IsToken ? "token" : "key")}:{string.Join(", ", CacheKeys?.Select(x => x) ?? Array.Empty<object>())}";
+        }
     }
 }

--- a/VirtoCommerce.Storefront/Caching/Redis/RedisCachingMessage.cs
+++ b/VirtoCommerce.Storefront/Caching/Redis/RedisCachingMessage.cs
@@ -1,11 +1,13 @@
 namespace VirtoCommerce.Storefront.Caching.Redis
 {
-    public class RedisCachingMessage
+    internal class RedisCachingMessage
     {
         public string Id { get; set; }
 
         public object[] CacheKeys { get; set; }
 
         public bool IsPrefix { get; set; }
+
+        public bool IsToken { get; set; }
     }
 }

--- a/VirtoCommerce.Storefront/Caching/Redis/RedisStorefrontMemoryCache.cs
+++ b/VirtoCommerce.Storefront/Caching/Redis/RedisStorefrontMemoryCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,12 +14,13 @@ namespace VirtoCommerce.Storefront.Caching.Redis
 {
     internal class RedisStorefrontMemoryCache : StorefrontMemoryCache
     {
-        public static string ServerId { get; } = $"{Environment.MachineName}_{Guid.NewGuid():N}";
+        private static string _instanceId { get; } = $"{Environment.MachineName}_{Guid.NewGuid():N}";
 
         private readonly ISubscriber _bus;
         private readonly RedisCachingOptions _redisCachingOptions;
         private readonly StorefrontOptions _storefrontOptions;
         private readonly IConnectionMultiplexer _connection;
+        private readonly ILogger<RedisStorefrontMemoryCache> _log;
 
         private bool _disposed;
 
@@ -30,6 +32,7 @@ namespace VirtoCommerce.Storefront.Caching.Redis
             ) : base(memoryCache, cachingOptions, loggerFactory, workContextAccessor)
         {
             _connection = ConnectionMultiplexer.Connect(redisCachingOptions.Value.Configuration);
+            _log = loggerFactory?.CreateLogger<RedisStorefrontMemoryCache>();
 
             _redisCachingOptions = redisCachingOptions.Value;
             _storefrontOptions = cachingOptions.Value;
@@ -37,12 +40,25 @@ namespace VirtoCommerce.Storefront.Caching.Redis
             _connection.ConnectionFailed += OnConnectionFailed;
             _connection.ConnectionRestored += OnConnectionRestored;
 
+            CacheCancellableTokensRegistry.OnTokenCancelled = CacheCancellableTokensRegistry_OnTokenCancelled;
+
             _bus = _connection.GetSubscriber();
             _bus.Subscribe(_redisCachingOptions.ChannelName, OnMessage, CommandFlags.FireAndForget);
+
+            _log.LogTrace($"Subscribe to Redis backplane channel {_redisCachingOptions.ChannelName } with instance id:{ _instanceId }");
+        }
+
+        private void CacheCancellableTokensRegistry_OnTokenCancelled(TokenCancelledEventArgs e)
+        {
+            var message = new RedisCachingMessage { Id = _instanceId, IsToken = true, CacheKeys = new[] { e.TokenKey } };
+            Publish(message);
+            _log.LogTrace($"Published token cancellation message {message}");
         }
 
         protected virtual void OnConnectionFailed(object sender, ConnectionFailedEventArgs e)
         {
+            _log.LogError($"Redis disconnected from instance { _instanceId }. Endpoint is {e.EndPoint}, failure type is {e.FailureType}");
+
             // If we have no connection to Redis, we can't invalidate cache on another platform instances,
             // so the better idea is to disable cache at all for data consistence
             CacheEnabled = false;
@@ -53,6 +69,8 @@ namespace VirtoCommerce.Storefront.Caching.Redis
 
         protected virtual void OnConnectionRestored(object sender, ConnectionFailedEventArgs e)
         {
+            _log.LogTrace($"Redis backplane connection restored for instance { _instanceId }");
+
             // Return cache to the same state as it was initially.
             // Don't set directly true because it may be disabled in app settings
             CacheEnabled = _storefrontOptions.CacheEnabled;
@@ -66,21 +84,39 @@ namespace VirtoCommerce.Storefront.Caching.Redis
         {
             var message = JsonConvert.DeserializeObject<RedisCachingMessage>(redisValue);
 
-            if (!string.IsNullOrEmpty(message.Id) && !message.Id.EqualsInvariant(ServerId))
+            if (!string.IsNullOrEmpty(message.Id) && !message.Id.EqualsInvariant(_instanceId))
             {
-                foreach (var item in message.CacheKeys)
+                _log.LogInformation($"Received RedisCachingMessage from instance: {message.Id}");
+
+                foreach (var key in message.CacheKeys?.OfType<string>() ?? Array.Empty<string>())
                 {
-                    base.Remove(item);
+                    if (message.IsToken)
+                    {
+                        _log.LogTrace($"Trying to cancel token with key: {key}");
+                        CacheCancellableTokensRegistry.TryCancelToken(key, raiseEvent: false);
+                    }
+                    else
+                    {
+                        _log.LogTrace($"Trying to remove cache entry with key: {key} from in-memory cache");
+                        base.Remove(key);
+                    }
                 }
             }
         }
 
         protected override void EvictionCallback(object key, object value, EvictionReason reason, object state)
         {
-            var message = new RedisCachingMessage { Id = ServerId, CacheKeys = new[] { key } };
-            _bus.Publish(_redisCachingOptions.ChannelName, JsonConvert.SerializeObject(message), CommandFlags.FireAndForget);
+            _log.LogTrace($"Publishing a message with key:{key} from instance:{ _instanceId } to all subscribers");
+
+            var message = new RedisCachingMessage { Id = _instanceId, CacheKeys = new[] { key } };
+            Publish(message);
 
             base.EvictionCallback(key, value, reason, state);
+        }
+
+        private void Publish(RedisCachingMessage message)
+        {
+            _bus.Publish(_redisCachingOptions.ChannelName, JsonConvert.SerializeObject(message), CommandFlags.FireAndForget);
         }
 
         protected override void Dispose(bool disposing)

--- a/VirtoCommerce.Storefront/Domain/Customer/CutomerCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/Customer/CutomerCacheRegion.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Threading;
 using Microsoft.Extensions.Primitives;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
@@ -8,24 +6,21 @@ namespace VirtoCommerce.Storefront.Domain
 {
     public class CustomerCacheRegion : CancellableCacheRegion<CustomerCacheRegion>
     {
-        private static readonly ConcurrentDictionary<string, CancellationTokenSource> _memberRegionTokenLookup =
-          new ConcurrentDictionary<string, CancellationTokenSource>();
-
         public static IChangeToken CreateChangeToken(string memberId)
         {
             if (memberId == null)
             {
                 throw new ArgumentNullException(nameof(memberId));
             }
-            var cancellationTokenSource = _memberRegionTokenLookup.GetOrAdd(memberId, new CancellationTokenSource());
-            return new CompositeChangeToken(new[] { CreateChangeToken(), new CancellationChangeToken(cancellationTokenSource.Token) });
+
+            return CreateChangeTokenForKey(memberId);
         }
 
         public static void ExpireMember(string memberId)
         {
-            if (!string.IsNullOrEmpty(memberId) && _memberRegionTokenLookup.TryRemove(memberId, out var token))
+            if (!string.IsNullOrEmpty(memberId))
             {
-                token.Cancel();
+                ExpireTokenForKey(memberId);
             }
         }
     }

--- a/VirtoCommerce.Storefront/Domain/Inventory/InventoryCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/Inventory/InventoryCacheRegion.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
 namespace VirtoCommerce.Storefront.Domain

--- a/VirtoCommerce.Storefront/Domain/Quote/QuoteCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/Quote/QuoteCacheRegion.cs
@@ -1,7 +1,5 @@
-using Microsoft.Extensions.Primitives;
 using System;
-using System.Collections.Concurrent;
-using System.Threading;
+using Microsoft.Extensions.Primitives;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 using VirtoCommerce.Storefront.Model.Quote;
 
@@ -9,24 +7,21 @@ namespace VirtoCommerce.Storefront.Domain
 {
     public class QuoteCacheRegion : CancellableCacheRegion<QuoteCacheRegion>
     {
-        private static readonly ConcurrentDictionary<QuoteRequest, CancellationTokenSource> _quoteRegionLookup = new ConcurrentDictionary<QuoteRequest, CancellationTokenSource>();
-
         public static IChangeToken CreateChangeToken(QuoteRequest qoute)
         {
             if (qoute == null)
             {
                 throw new ArgumentNullException(nameof(qoute));
             }
-            var cancellationTokenSource = _quoteRegionLookup.GetOrAdd(qoute, new CancellationTokenSource());
-            return new CompositeChangeToken(new[] { CreateChangeToken(), new CancellationChangeToken(cancellationTokenSource.Token) });
+
+            return CreateChangeTokenForKey(qoute.GetCacheKey());
         }
 
         public static void ExpireQuote(QuoteRequest qoute)
         {
-            if (_quoteRegionLookup.TryRemove(qoute, out CancellationTokenSource token))
+            if (qoute != null)
             {
-                token.Cancel();
-                token.Dispose();
+                ExpireTokenForKey(qoute.GetCacheKey());
             }
         }
     }

--- a/VirtoCommerce.Storefront/Domain/Recommendations/RecommendationsCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/Recommendations/RecommendationsCacheRegion.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
 namespace VirtoCommerce.Storefront.Domain

--- a/VirtoCommerce.Storefront/Domain/Security/SecurityCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/Security/SecurityCacheRegion.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Threading;
 using Microsoft.Extensions.Primitives;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
@@ -8,24 +6,21 @@ namespace VirtoCommerce.Storefront.Domain.Security
 {
     public class SecurityCacheRegion : CancellableCacheRegion<SecurityCacheRegion>
     {
-        private static readonly ConcurrentDictionary<string, CancellationTokenSource> _securityCacheRegionTokenLookup =
-         new ConcurrentDictionary<string, CancellationTokenSource>();
-
         public static IChangeToken CreateChangeToken(string userId)
         {
             if (userId == null)
             {
                 throw new ArgumentNullException(nameof(userId));
             }
-            var cancellationTokenSource = _securityCacheRegionTokenLookup.GetOrAdd(userId, new CancellationTokenSource());
-            return new CompositeChangeToken(new[] { CreateChangeToken(), new CancellationChangeToken(cancellationTokenSource.Token) });
+
+            return CreateChangeTokenForKey(userId);
         }
 
         public static void ExpireUser(string userId)
         {
-            if (!string.IsNullOrEmpty(userId) && _securityCacheRegionTokenLookup.TryRemove(userId, out var token))
+            if (!string.IsNullOrEmpty(userId))
             {
-                token.Cancel();
+                ExpireTokenForKey(userId);
             }
         }
     }

--- a/VirtoCommerce.Storefront/Domain/StaticContent/StaticContentCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/StaticContent/StaticContentCacheRegion.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
 namespace VirtoCommerce.Storefront.Domain

--- a/VirtoCommerce.Storefront/Domain/Subscriptions/PaymentPlanCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/Subscriptions/PaymentPlanCacheRegion.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
 namespace VirtoCommerce.Storefront.Domain

--- a/VirtoCommerce.Storefront/Domain/Subscriptions/SubscriptionCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/Subscriptions/SubscriptionCacheRegion.cs
@@ -1,9 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Primitives;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
@@ -11,24 +6,21 @@ namespace VirtoCommerce.Storefront.Domain
 {
     public class SubscriptionCacheRegion : CancellableCacheRegion<SubscriptionCacheRegion>
     {
-        private static readonly ConcurrentDictionary<string, CancellationTokenSource> _customerSubscriptionRegionTokenLookup =
-        new ConcurrentDictionary<string, CancellationTokenSource>();
-
         public static IChangeToken CreateCustomerSubscriptionChangeToken(string customerId)
         {
             if (customerId == null)
             {
                 throw new ArgumentNullException(nameof(customerId));
             }
-            var cancellationTokenSource = _customerSubscriptionRegionTokenLookup.GetOrAdd(customerId, new CancellationTokenSource());
-            return new CompositeChangeToken(new[] { CreateChangeToken(), new CancellationChangeToken(cancellationTokenSource.Token) });
+
+            return CreateChangeTokenForKey(customerId);
         }
 
         public static void ExpireCustomerSubscription(string customerId)
         {
-            if (!string.IsNullOrEmpty(customerId) && _customerSubscriptionRegionTokenLookup.TryRemove(customerId, out var token))
+            if (!string.IsNullOrEmpty(customerId))
             {
-                token.Cancel();
+                ExpireTokenForKey(customerId);
             }
         }
     }

--- a/VirtoCommerce.Storefront/Domain/Tax/TaxCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Domain/Tax/TaxCacheRegion.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
 namespace VirtoCommerce.Storefront.Domain

--- a/VirtoCommerce.Storefront/Routing/RoutingCacheRegion.cs
+++ b/VirtoCommerce.Storefront/Routing/RoutingCacheRegion.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using VirtoCommerce.Storefront.Model.Common.Caching;
 
 namespace VirtoCommerce.Storefront.Routing


### PR DESCRIPTION
Cache invalidation should be propagated to the Redis backplane to all instances, no matter if the instance got invalidation message contains record with that key or not.

Similar to the platform commits:
https://github.com/VirtoCommerce/vc-platform/commit/61aea3790c5beb19b2bf9f0eeeffc1bbeff962f4#diff-390f6702ff1f2d8cf904c1cb7570efb4
https://github.com/VirtoCommerce/vc-platform/commit/bbb8c318dfb6b6de8869bc4372ac403629512a00