### PR TITLE
VP-2342: Rework ConfirmEmail method to get passed user instead of the current one

### DIFF
--- a/VirtoCommerce.Storefront/Controllers/AccountController.cs
+++ b/VirtoCommerce.Storefront/Controllers/AccountController.cs
@@ -255,10 +255,26 @@ namespace VirtoCommerce.Storefront.Controllers
 
         [HttpGet("confirmemail")]
         [AllowAnonymous]
-        public async Task<ActionResult> ConfirmEmail(string token)
+        public async Task<ActionResult> ConfirmEmail(string userId, string token)
         {
-            var result = await _signInManager.UserManager.ConfirmEmailAsync(WorkContext.CurrentUser, token);
+            if (string.IsNullOrEmpty(userId))
+            {
+                WorkContext.Form.Errors.Add(SecurityErrorDescriber.UserNotFound());
+                return View("error", WorkContext);
+            }
+
+            var user = await _signInManager.UserManager.FindByIdAsync(userId);
+
+            if (user == null)
+            {
+                WorkContext.Form.Errors.Add(SecurityErrorDescriber.UserNotFound());
+                return View("error", WorkContext);
+            }
+
+            var result = await _signInManager.UserManager.ConfirmEmailAsync(user, token);
+
             var viewName = result.Succeeded ? "confirmation-done" : "error";
+
             return View(viewName);
         }
 


### PR DESCRIPTION
**Problem**
User confirmation took the user based on the currently logged in user, which is incorrect. User should be passed as a method parameter to allow not logged in user to confirm their emails.

**Solution**
Use passed userId to find the user for the email confirmation.