### PR TITLE
ValueObjects with different values should not be equal and should have different cache keys

### DIFF
--- a/VirtoCommerce.Storefront.Model/Common/ValueObject.cs
+++ b/VirtoCommerce.Storefront.Model/Common/ValueObject.cs
@@ -4,7 +4,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Web;
 
 namespace VirtoCommerce.Storefront.Model.Common
 {
@@ -49,7 +48,11 @@ namespace VirtoCommerce.Storefront.Model.Common
 
         public virtual string GetCacheKey()
         {
-            return string.Join("|", GetEqualityComponents().Select(x => x ?? "null").Select(x => x is ICacheKey cacheKey ? cacheKey.GetCacheKey() : x.ToString()));
+            var keyValues = GetEqualityComponents()
+                .Select(x => x is string ? $"'{x}'" : x)
+                .Select(x => x is ICacheKey cacheKey ? cacheKey.GetCacheKey() : x?.ToString());
+
+            return string.Join("|", keyValues);
         }
 
         protected virtual IEnumerable<object> GetEqualityComponents()
@@ -59,17 +62,19 @@ namespace VirtoCommerce.Storefront.Model.Common
                 var value = property.GetValue(this);
                 if (value == null)
                 {
-                    yield return "null";
+                    yield return null;
                 }
                 else
                 {
                     var valueType = value.GetType();
                     if (valueType.IsAssignableFromGenericList())
                     {
+                        yield return '[';
                         foreach (var child in ((IEnumerable)value))
                         {
-                            yield return child ?? "null";
+                            yield return child;
                         }
+                        yield return ']';
                     }
                     else
                     {

--- a/VirtoCommerce.Storefront.Tests/ValueObjectTests.cs
+++ b/VirtoCommerce.Storefront.Tests/ValueObjectTests.cs
@@ -52,7 +52,7 @@ namespace VirtoCommerce.Storefront.Tests
 
                         var equals = object1.Equals(object2);
 
-                        Assert.False(equals);
+                        Assert.False(equals, $"Objects #{i} and #{j} must not be equal.");
                     }
                 }
             }

--- a/VirtoCommerce.Storefront.Tests/ValueObjectTests.cs
+++ b/VirtoCommerce.Storefront.Tests/ValueObjectTests.cs
@@ -1,19 +1,23 @@
 using System.Collections.Generic;
+using System.Linq;
 using VirtoCommerce.Storefront.Model.Common;
 using Xunit;
 
 namespace VirtoCommerce.Storefront.Tests
 {
+    [Trait("Category", "Unit")]
     public class ValueObjectTests
     {
         public class ComplexObject : ValueObject
         {
+            public string SimpleProperty { get; set; }
+            public string AnotherSimpleProperty { get; set; }
             public List<string> ListProperty { get; set; }
-            public string SimpleProperty { get; set; }         
+            public List<string> AnotherListProperty { get; set; }
         }
-      
+
         [Fact]
-        public void SameObjectHashCodeAreSame()
+        public void ObjectsWithTheSameValuesShouldBeEqual()
         {
             var value1 = new ComplexObject
             {
@@ -31,5 +35,66 @@ namespace VirtoCommerce.Storefront.Tests
             Assert.Equal(value1, value2);
         }
 
+        [Fact]
+        public void ObjectsWithDifferentValuesShouldNotBeEqual()
+        {
+            var objectsWithDifferentValues = GetObjectsWithDifferentValues();
+
+            // Compare each object with all other objects
+            for (var i = 0; i < objectsWithDifferentValues.Count; i++)
+            {
+                for (var j = 0; j < objectsWithDifferentValues.Count; j++)
+                {
+                    if (i != j)
+                    {
+                        var object1 = objectsWithDifferentValues[i];
+                        var object2 = objectsWithDifferentValues[j];
+
+                        var equals = object1.Equals(object2);
+
+                        Assert.False(equals);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void ObjectsWithDifferentValuesShouldHaveDifferentCacheKeys()
+        {
+            var objectsWithDifferentValues = GetObjectsWithDifferentValues();
+
+            var cacheKeys = objectsWithDifferentValues.Select(x => x.GetCacheKey()).ToList();
+            var uniqueCacheKeys = cacheKeys.Distinct().ToList();
+
+            Assert.Equal(objectsWithDifferentValues.Count, uniqueCacheKeys.Count);
+        }
+
+
+        private static IList<ComplexObject> GetObjectsWithDifferentValues()
+        {
+            return new[]
+            {
+                // All properties are null
+                new ComplexObject(),
+
+                new ComplexObject { SimpleProperty = "" },
+                new ComplexObject { SimpleProperty = "null" },
+
+                new ComplexObject { AnotherSimpleProperty = "" },
+                new ComplexObject { AnotherSimpleProperty = "null" },
+
+                // ListProperty is not null
+                new ComplexObject { ListProperty = new List<string>() },
+                new ComplexObject { ListProperty = new List<string> { null } },
+                new ComplexObject { ListProperty = new List<string> { "" } },
+                new ComplexObject { ListProperty = new List<string> { "null" } },
+
+                // AnotherListProperty is not null
+                new ComplexObject { AnotherListProperty = new List<string>() },
+                new ComplexObject { AnotherListProperty = new List<string> { null } },
+                new ComplexObject { AnotherListProperty = new List<string> { "" } },
+                new ComplexObject { AnotherListProperty = new List<string> { "null" } },
+            };
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the following issues that lead to incorrect equality components and duplicate cache keys:
1. `null` and `"null"` values are considered equal.
2. Empty collections are just ignored.