### PR TITLE
We should check and get the defaultStoreId first

### DIFF
--- a/VirtoCommerce.Storefront/Domain/Stores/SelectCurrentStorePolicy.cs
+++ b/VirtoCommerce.Storefront/Domain/Stores/SelectCurrentStorePolicy.cs
@@ -20,13 +20,13 @@ namespace VirtoCommerce.Storefront.Domain
             //Try first find by store url (if it defined)
             var result = stores.FirstOrDefault(x => context.Request.Path.StartsWithSegments(new PathString("/" + x.Id)));
 
-            if (result == null)
-            {
-                result = stores.FirstOrDefault(x => x.IsStoreUrl(context.Request.GetUri()));
-            }
             if (result == null && defaultStoreId != null)
             {
                 result = stores.FirstOrDefault(x => x.Id.EqualsInvariant(defaultStoreId));
+            }
+            if (result == null)
+            {
+                result = stores.FirstOrDefault(x => x.IsStoreUrl(context.Request.GetUri()));
             }
             if (result == null)
             {


### PR DESCRIPTION
In case we config default store id in setting file, we should check the condition and get store by defaultStoreId before fallback to get default store.
