### PR TITLE
ST-1812: Storefront migration to .NET 6

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -25,6 +25,6 @@ jobs:
       uploadDocker: 'true'
       eventName: ${{ github.event_name }}
       imageName: 'storefront'
-      dockerFiles: 'https://raw.githubusercontent.com/VirtoCommerce/vc-docker/master/linux/storefront/Dockerfile'
+      dockerFiles: 'https://raw.githubusercontent.com/VirtoCommerce/vc-docker/feat/net6/linux/storefront/Dockerfile'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
+++ b/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
@@ -251,7 +251,7 @@ namespace VirtoCommerce.LiquidThemeEngine
                 {
                     throw new StorefrontException($"Theme resource for path '{filePath}' not found");
                 }
-                var hashAlgorithm = CryptoConfig.AllowOnlyFipsAlgorithms ? (SHA256)new SHA256CryptoServiceProvider() : new SHA256Managed();
+                var hashAlgorithm = CryptoConfig.AllowOnlyFipsAlgorithms ? SHA256CryptoServiceProvider.Create() : SHA256Managed.Create();
                 return WebEncoders.Base64UrlEncode(hashAlgorithm.ComputeHash(stream));
             });
         }

--- a/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
+++ b/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
@@ -251,7 +251,7 @@ namespace VirtoCommerce.LiquidThemeEngine
                 {
                     throw new StorefrontException($"Theme resource for path '{filePath}' not found");
                 }
-                var hashAlgorithm = CryptoConfig.AllowOnlyFipsAlgorithms ? SHA256CryptoServiceProvider.Create() : SHA256Managed.Create();
+                var hashAlgorithm = SHA256.Create();
                 return WebEncoders.Base64UrlEncode(hashAlgorithm.ComputeHash(stream));
             });
         }

--- a/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
+++ b/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
@@ -364,7 +364,7 @@ namespace VirtoCommerce.LiquidThemeEngine
                 NewLine = Environment.NewLine,
                 TemplateLoaderLexerOptions = new LexerOptions
                 {
-                    Mode = ScriptMode.Liquid
+                    Mode = ScriptMode.Default
                 }
             };
             templateContext.PushGlobal(scriptObject);

--- a/VirtoCommerce.LiquidThemeEngine/VirtoCommerce.LiquidThemeEngine.csproj
+++ b/VirtoCommerce.LiquidThemeEngine/VirtoCommerce.LiquidThemeEngine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Description>The storefront implementation of the Virto Commerce platform.</Description>
     <PackageLicenseUrl>https://virtocommerce.com/open-source-license</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/VirtoCommerce/vc-storefront-core</PackageProjectUrl>
@@ -14,15 +14,15 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="GraphQL.Client" Version="3.1.9" />
-    <PackageReference Include="LibSassHost" Version="1.3.0" />
-    <PackageReference Include="LibSassHost.Native.linux-x64" Version="1.2.10" />
-    <PackageReference Include="LibSassHost.Native.osx-x64" Version="1.3.1" />
-    <PackageReference Include="LibSassHost.Native.win-x64" Version="1.2.10" />
-    <PackageReference Include="LibSassHost.Native.win-x86" Version="1.2.10" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
+    <PackageReference Include="GraphQL.Client" Version="4.0.2" />
+    <PackageReference Include="LibSassHost" Version="1.3.3" />
+    <PackageReference Include="LibSassHost.Native.linux-x64" Version="1.3.3" />
+    <PackageReference Include="LibSassHost.Native.osx-x64" Version="1.3.3" />
+    <PackageReference Include="LibSassHost.Native.win-x64" Version="1.3.3" />
+    <PackageReference Include="LibSassHost.Native.win-x86" Version="1.3.3" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="PagedList.Core" Version="1.17.4" />
-    <PackageReference Include="Scriban" Version="2.1.2" />
+    <PackageReference Include="Scriban" Version="5.4.4" />
   </ItemGroup>
 
 

--- a/VirtoCommerce.Storefront.Model/VirtoCommerce.Storefront.Model.csproj
+++ b/VirtoCommerce.Storefront.Model/VirtoCommerce.Storefront.Model.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!--Need to include TargetLatestRuntimePatch, otherwise get following error about ASP NET Core restored version-->
     <!--https://stackoverflow.com/questions/51642172/the-project-was-restored-using-microsoft-netcore-app-version-2-1-0-but-with-cur-->
     <!--https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-patch-selection-->
@@ -17,9 +17,9 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
-    <PackageReference Include="FluentValidation" Version="8.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.4" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="PagedList.Core" Version="1.17.4" />
   </ItemGroup>
 

--- a/VirtoCommerce.Storefront.Tests/LiquidThemeEngine/ShopifyLiquidThemeEngineTests.cs
+++ b/VirtoCommerce.Storefront.Tests/LiquidThemeEngine/ShopifyLiquidThemeEngineTests.cs
@@ -28,9 +28,9 @@ namespace VirtoCommerce.Storefront.Tests.LiquidThemeEngine
         }
 
         private static readonly string ThemesPath = "Themes";
-        private static readonly string BaseThemePath = "odt\\default";
-        private static readonly string CurrentThemePath = "odt\\current";
-        private static readonly string SettingsPath = "config\\settings_data.json";
+        private static readonly string BaseThemePath = $"odt{Path.DirectorySeparatorChar}default";
+        private static readonly string CurrentThemePath = $"odt{Path.DirectorySeparatorChar}current";
+        private static readonly string SettingsPath = $"config{Path.DirectorySeparatorChar}settings_data.json";
 
         private static JObject DefaultSettingsWithoutPresets => JObject.Parse(@"
         {
@@ -141,7 +141,7 @@ namespace VirtoCommerce.Storefront.Tests.LiquidThemeEngine
         {
             var options = new LiquidThemeEngineOptions()
             {
-                BaseThemePath = "odt\\default"
+                BaseThemePath = $"odt{Path.DirectorySeparatorChar}default"
             };
 
             Check_Inheritance_Backward_Compatibility(options);
@@ -181,7 +181,7 @@ namespace VirtoCommerce.Storefront.Tests.LiquidThemeEngine
         {
             var options = new LiquidThemeEngineOptions()
             {
-                BaseThemePath = "odt\\default",
+                BaseThemePath = $"odt{Path.DirectorySeparatorChar}default",
                 MergeBaseSettings = true
             };
             var shopifyLiquidThemeEngine = GetThemeEngine(true, options);

--- a/VirtoCommerce.Storefront.Tests/LiquidThemeEngine/ShopifyLiquidThemeEngineTests.cs
+++ b/VirtoCommerce.Storefront.Tests/LiquidThemeEngine/ShopifyLiquidThemeEngineTests.cs
@@ -207,7 +207,7 @@ namespace VirtoCommerce.Storefront.Tests.LiquidThemeEngine
             CurrentThemeStream = currentThemeStream;
         }
 
-        private void InitializeStream<T>(StreamWriter writer, out Stream stream, T content)
+        private static void InitializeStream<T>(StreamWriter writer, out Stream stream, T content)
         {
             // Clear
             writer.BaseStream.Position = 0;
@@ -241,7 +241,7 @@ namespace VirtoCommerce.Storefront.Tests.LiquidThemeEngine
             }
         }
 
-        public IStorefrontMemoryCache MemoryCache
+        public static IStorefrontMemoryCache MemoryCache
         {
             get
             {
@@ -258,7 +258,7 @@ namespace VirtoCommerce.Storefront.Tests.LiquidThemeEngine
             }
         }
 
-        private IWorkContextAccessor GetWorkContextAccessor(bool useThemesInheritance)
+        private static IWorkContextAccessor GetWorkContextAccessor(bool useThemesInheritance)
         {
             var mock = new Mock<IWorkContextAccessor>();
             mock.Setup(service => service.WorkContext)
@@ -273,7 +273,7 @@ namespace VirtoCommerce.Storefront.Tests.LiquidThemeEngine
             return mock.Object;
         }
 
-        private IHttpContextAccessor HttpContextAccessor
+        private static IHttpContextAccessor HttpContextAccessor
         {
             get
             {

--- a/VirtoCommerce.Storefront.Tests/VirtoCommerce.Storefront.Tests.csproj
+++ b/VirtoCommerce.Storefront.Tests/VirtoCommerce.Storefront.Tests.csproj
@@ -1,30 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="29.0.2" />
-    <PackageReference Include="FluentValidation" Version="8.6.2" />
+    <PackageReference Include="Bogus" Version="34.0.2" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.3" />
-    <PackageReference Include="FluentValidation" Version="8.6.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="PagedList.Core" Version="1.17.4" />
-    <PackageReference Include="Scriban" Version="2.1.2" />
+    <PackageReference Include="Scriban" Version="5.4.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -281,8 +281,7 @@ namespace VirtoCommerce.Storefront
                 options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
                 options.SerializerSettings.MissingMemberHandling = MissingMemberHandling.Ignore;
             })
-             .AddFluentValidation()
-            .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+             .AddFluentValidation();
 
 
             // Register event handlers via reflection

--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>0cd403c4-2cd0-42b3-987a-02900f4a683e</UserSecretsId>
     <Description>The storefront implementation of the Virto Commerce platform.</Description>
@@ -38,40 +38,40 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="3.1.0" />
-    <PackageReference Include="AspNet.Security.OAuth.StackExchange" Version="3.1.0" />
-    <PackageReference Include="GraphQL.Client" Version="3.1.9" />
-    <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="3.1.9" />
-    <PackageReference Include="IdentityModel" Version="4.2.0" />
-    <PackageReference Include="FluentValidation" Version="8.6.2" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="6.0.6" />
+    <PackageReference Include="AspNet.Security.OAuth.StackExchange" Version="6.0.6" />
+    <PackageReference Include="GraphQL.Client" Version="4.0.2" />
+    <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="4.0.2" />
+    <PackageReference Include="IdentityModel" Version="6.0.0" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     
-    <PackageReference Include="Markdig" Version="0.20.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.7.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Web" Version="2.15.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="3.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
+    <PackageReference Include="Markdig" Version="0.30.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.20.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.3" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Web" Version="2.20.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.4" />
     <PackageReference Include="Microsoft.AutoRest.Common" Version="2.4.48" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Microsoft.SyndicationFeed.ReaderWriter" Version="1.0.2" />
-    <PackageReference Include="MimeTypes" Version="1.1.0">
+    <PackageReference Include="MimeTypes" Version="2.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="PagedList.Core" Version="1.17.4" />
-    <PackageReference Include="Polly" Version="7.2.0" />
-    <PackageReference Include="ProxyKit" Version="2.3.3" />
-    <PackageReference Include="Scrutor" Version="3.2.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.1.30" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.3.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.3.3" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.3.3" />
-	<PackageReference Include="VirtoCommerce.Tools" Version="3.4.0" />
+    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="ProxyKit" Version="2.3.4" />
+    <PackageReference Include="Scrutor" Version="4.1.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.5.61" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.1" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.3.1" />
+	<PackageReference Include="VirtoCommerce.Tools" Version="3.200.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 

--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -70,8 +70,8 @@
     <PackageReference Include="StackExchange.Redis" Version="2.5.61" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.1" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.3.1" />
-	<PackageReference Include="VirtoCommerce.Tools" Version="3.200.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.3.1" />
+    <PackageReference Include="VirtoCommerce.Tools" Version="3.200.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Description: 
Closes ST-1218. Migrating vc-storefront to .NET6, upgrading dependencies.

--

QA-test: ST-1954

Demo-test: ST-1955

Download artifact URL: ghcr.io/virtocommerce/storefront:6.0.0-pr-602-dotnet-6-migration-5d6ae016
