### PR TITLE
feat(ST-2696): implement the endpoint to get seoInfo for objects or static content by slug

### DIFF
--- a/VirtoCommerce.Storefront.Model/ISeoInfoService.cs
+++ b/VirtoCommerce.Storefront.Model/ISeoInfoService.cs
@@ -1,9 +1,12 @@
 using System.Threading.Tasks;
+using VirtoCommerce.Storefront.Model.Stores;
 
 namespace VirtoCommerce.Storefront.Model
 {
     public interface ISeoInfoService
     {
         Task<SeoInfo[]> GetSeoInfosBySlug(string slug);
+
+        Task<SeoInfo[]> GetBestMatchingSeoInfos(string slug, Store store, string currentCulture);
     }
 }

--- a/VirtoCommerce.Storefront.Model/SlugInfoResult.cs
+++ b/VirtoCommerce.Storefront.Model/SlugInfoResult.cs
@@ -1,0 +1,11 @@
+using VirtoCommerce.Storefront.Model.StaticContent;
+
+namespace VirtoCommerce.Storefront.Model
+{
+    public class SlugInfoResult
+    {
+        public ContentItem ContentItem { get; set; }
+
+        public SeoInfo EntityInfo { get; set; }
+    }
+}

--- a/VirtoCommerce.Storefront/Controllers/Api/ApiCommonController.cs
+++ b/VirtoCommerce.Storefront/Controllers/Api/ApiCommonController.cs
@@ -57,10 +57,33 @@ namespace VirtoCommerce.Storefront.Controllers.Api
             return Ok();
         }
 
-        [HttpGet("seoInfos/{slug}")]
-        public async Task<SeoInfo[]> GetSeoInfosAsync(string slug)
+        [HttpGet("slug/{slug}")]
+        public async Task<SlugInfoResult> GetInfoBySlugAsync(string slug, [FromQuery] string culture)
         {
-            return await _seoInfoService.GetSeoInfosBySlug(slug);
+            var result = new SlugInfoResult();
+
+            try
+            {
+                result.ContentItem = WorkContext.Pages.FirstOrDefault(x => x.Permalink != null
+                                                                        && x.Permalink.EqualsInvariant($"/{slug}")
+                                                                        && x.Language.CultureName.EqualsInvariant(culture))
+                    ?? WorkContext.Pages.FirstOrDefault(x => x.Permalink != null
+                                                                        && x.Permalink.EqualsInvariant($"/{slug}")
+                                                                        && x.Language.IsInvariant);
+            }
+            catch
+            {
+                //do nothing
+            }
+
+            if (result.ContentItem == null)
+            {
+                var seoInfos = await _seoInfoService.GetSeoInfosBySlug(slug);
+
+                result.EntityInfo = seoInfos.FirstOrDefault(x => x.Language.CultureName.EqualsInvariant(culture));
+            }
+
+            return result;
         }
     }
 }

--- a/VirtoCommerce.Storefront/Controllers/Api/ApiCommonController.cs
+++ b/VirtoCommerce.Storefront/Controllers/Api/ApiCommonController.cs
@@ -62,25 +62,28 @@ namespace VirtoCommerce.Storefront.Controllers.Api
         {
             var result = new SlugInfoResult();
 
-            try
-            {
-                result.ContentItem = WorkContext.Pages.FirstOrDefault(x => x.Permalink != null
-                                                                        && x.Permalink.EqualsInvariant($"/{slug}")
-                                                                        && x.Language.CultureName.EqualsInvariant(culture))
-                    ?? WorkContext.Pages.FirstOrDefault(x => x.Permalink != null
-                                                                        && x.Permalink.EqualsInvariant($"/{slug}")
-                                                                        && x.Language.IsInvariant);
-            }
-            catch
-            {
-                //do nothing
-            }
+            var seoInfos = await _seoInfoService.GetBestMatchingSeoInfos(slug, WorkContext.CurrentStore, culture);
 
-            if (result.ContentItem == null)
-            {
-                var seoInfos = await _seoInfoService.GetSeoInfosBySlug(slug);
+            var bestSeoInfo = seoInfos.FirstOrDefault();
 
-                result.EntityInfo = seoInfos.FirstOrDefault(x => x.Language.CultureName.EqualsInvariant(culture));
+            result.EntityInfo = bestSeoInfo;
+
+
+            if (result.EntityInfo == null)
+            {
+                try
+                {
+                    result.ContentItem = WorkContext.Pages.FirstOrDefault(x => x.Permalink != null
+                                                                            && x.Permalink.EqualsInvariant($"/{slug}")
+                                                                            && x.Language.CultureName.EqualsInvariant(culture))
+                        ?? WorkContext.Pages.FirstOrDefault(x => x.Permalink != null
+                                                                            && x.Permalink.EqualsInvariant($"/{slug}")
+                                                                            && x.Language.IsInvariant);
+                }
+                catch
+                {
+                    //do nothing
+                }
             }
 
             return result;

--- a/VirtoCommerce.Storefront/Controllers/Api/ApiCommonController.cs
+++ b/VirtoCommerce.Storefront/Controllers/Api/ApiCommonController.cs
@@ -71,14 +71,15 @@ namespace VirtoCommerce.Storefront.Controllers.Api
 
             if (result.EntityInfo == null)
             {
+                var pageUrl = $"/{slug}";
                 try
                 {
-                    result.ContentItem = WorkContext.Pages.FirstOrDefault(x => x.Permalink != null
-                                                                            && x.Permalink.EqualsInvariant($"/{slug}")
-                                                                            && x.Language.CultureName.EqualsInvariant(culture))
-                        ?? WorkContext.Pages.FirstOrDefault(x => x.Permalink != null
-                                                                            && x.Permalink.EqualsInvariant($"/{slug}")
-                                                                            && x.Language.IsInvariant);
+                    var pages = WorkContext.Pages.Where(p => string.Equals(p.Url, pageUrl, StringComparison.OrdinalIgnoreCase));
+
+                    result.ContentItem = pages.FirstOrDefault(x => x.Language.CultureName.EqualsInvariant(culture))
+                                            ?? pages.FirstOrDefault(x => x.Language.IsInvariant)
+                                            ?? pages.FirstOrDefault(x => x.AliasesUrls.Contains(pageUrl, StringComparer.OrdinalIgnoreCase));
+
                 }
                 catch
                 {

--- a/VirtoCommerce.Storefront/Domain/SeoInfoServise.cs
+++ b/VirtoCommerce.Storefront/Domain/SeoInfoServise.cs
@@ -1,7 +1,9 @@
 using System.Linq;
 using System.Threading.Tasks;
 using VirtoCommerce.Storefront.AutoRestClients.CoreModuleApi;
+using VirtoCommerce.Storefront.Common;
 using VirtoCommerce.Storefront.Model;
+using VirtoCommerce.Storefront.Model.Stores;
 
 namespace VirtoCommerce.Storefront.Domain
 {
@@ -16,6 +18,13 @@ namespace VirtoCommerce.Storefront.Domain
         public async Task<SeoInfo[]> GetSeoInfosBySlug(string slug)
         {
             var result = (await _coreModuleApi.GetSeoInfoBySlugAsync(slug)).Select(x => x.ToSeoInfo()).ToArray();
+
+            return result;
+        }
+
+        public async Task<SeoInfo[]> GetBestMatchingSeoInfos(string slug, Store store, string currentCulture)
+        {
+            var result = (await _coreModuleApi.GetSeoInfoBySlugAsync(slug)).GetBestMatchingSeoInfos(store, currentCulture, slug).Select(x => x.ToSeoInfo()).ToArray();
 
             return result;
         }

--- a/VirtoCommerce.Storefront/Extensions/SeoExtensions.cs
+++ b/VirtoCommerce.Storefront/Extensions/SeoExtensions.cs
@@ -45,5 +45,23 @@ namespace VirtoCommerce.Storefront.Common
                 .Select(s => s.JsonConvert<coreDto.SeoInfo>())
                 .ToList();
         }
+
+        /// <summary>
+        /// Returns SEO records with highest score
+        /// http://docs.virtocommerce.com/display/vc2devguide/SEO
+        /// </summary>
+        /// <param name="seoRecords"></param>
+        /// <param name="store"></param>
+        /// <param name="currentCulture"></param>
+        /// <param name="slug"></param>
+        /// <returns></returns>
+        public static IList<coreDto.SeoInfo> GetBestMatchingSeoInfos(this IEnumerable<coreDto.SeoInfo> seoRecords, Store store, string currentCulture, string slug = null)
+        {
+            return seoRecords
+                ?.Select(s => s.JsonConvert<toolsDto.SeoInfo>())
+                .GetBestMatchingSeoInfos(store.Id, store.DefaultLanguage.CultureName, currentCulture, slug)
+                .Select(s => s.JsonConvert<coreDto.SeoInfo>())
+                .ToList();
+        }
     }
 }


### PR DESCRIPTION
Description: 


--

QA-test: ST-2697

Demo-test: 

Download artifact URL: ghcr.io/virtocommerce/storefront:6.3.0-pr-613-st-2696-slug-endpoint-1a47611d
