### PR TITLE
PT-13384: An blocked user received the error code email_verification_is_required

### DIFF
--- a/VirtoCommerce.Storefront.Model/Security/Specifications/IsUserLockedByRequiredEmailVerificationSpecification.cs
+++ b/VirtoCommerce.Storefront.Model/Security/Specifications/IsUserLockedByRequiredEmailVerificationSpecification.cs
@@ -1,12 +1,24 @@
+using VirtoCommerce.Storefront.Model.Common;
 using VirtoCommerce.Storefront.Model.Common.Specifications;
+using VirtoCommerce.Storefront.Model.Stores;
 
 namespace VirtoCommerce.Storefront.Model.Security.Specifications
 {
-    public class IsUserLockedByRequiredEmailVerificationSpecification : ISpecification<User>
+    public class IsUserLockedByRequiredEmailVerificationSpecification : ISpecification<Store>
     {
-        public virtual bool IsSatisfiedBy(User user)
+        private readonly User _user;
+
+        public IsUserLockedByRequiredEmailVerificationSpecification(User user)
         {
-            return user.Contact.Status == "Locked" && !user.EmailConfirmed;
+            _user = user;
+        }
+
+        public virtual bool IsSatisfiedBy(Store store)
+        {
+            return _user.Contact.Status == "Locked"
+                && !_user.EmailConfirmed
+                && store.Settings.GetSettingValue<bool>("Stores.EmailVerificationEnabled", false)
+                && store.Settings.GetSettingValue<bool>("Stores.EmailVerificationRequired", false);
         }
     }
 }

--- a/VirtoCommerce.Storefront/Controllers/Api/ApiAccountController.cs
+++ b/VirtoCommerce.Storefront/Controllers/Api/ApiAccountController.cs
@@ -99,7 +99,7 @@ namespace VirtoCommerce.Storefront.Controllers.Api
             {
                 if (loginResult.IsLockedOut)
                 {
-                    if (new IsUserLockedByRequiredEmailVerificationSpecification().IsSatisfiedBy(user))
+                    if (new IsUserLockedByRequiredEmailVerificationSpecification(user).IsSatisfiedBy(WorkContext.CurrentStore))
                     {
                         return UserActionIdentityResult.Failed(SecurityErrorDescriber.EmailVerificationIsRequired());
                     }


### PR DESCRIPTION
Description: 

fix: An blocked user received the error code email_verification_is_required. Extend IsUserLockedByRequiredEmailVerificationSpecification with Store Setting checking. email_verification_is_required returns if 

```cs
_user.Contact.Status == "Locked"
                && !_user.EmailConfirmed
                && store.Settings.GetSettingValue<bool>("Stores.EmailVerificationEnabled", false)
                && store.Settings.GetSettingValue<bool>("Stores.EmailVerificationRequired", false)
```

--

QA-test: 

Demo-test: 

Download artifact URL: 
