### PR TITLE
VCST-206: Proxy XAPI subscription websocket connections

### DIFF
--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -431,7 +431,10 @@ namespace VirtoCommerce.Storefront
             var platformEndpointOptions = app.ApplicationServices.GetRequiredService<IOptions<PlatformEndpointOptions>>().Value;
 
             var httpsPlatformGraphqlEndpoint = new Uri(platformEndpointOptions.Url, "graphql");
-            var wssPlatformGraphqlEndpoint = new UriBuilder(httpsPlatformGraphqlEndpoint) { Scheme = Uri.UriSchemeWss }.Uri;
+            var wssPlatformGraphqlEndpoint = new UriBuilder(httpsPlatformGraphqlEndpoint)
+            {
+                Scheme = httpsPlatformGraphqlEndpoint.Scheme == Uri.UriSchemeHttps ? Uri.UriSchemeWss : Uri.UriSchemeWs
+            }.Uri;
 
             app.UseWebSockets();
             app.Map("/xapi/graphql",

--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -342,6 +342,8 @@ namespace VirtoCommerce.Storefront
 
             services.AddProxy(builder => builder.AddHttpMessageHandler(sp => sp.GetService<AuthenticationHandlerFactory>().CreateAuthHandler()));
 
+            services.Configure<ProxyOptions>(options => options.WebSocketKeepAliveInterval = TimeSpan.FromSeconds(50));
+
             services.AddSingleton<IGraphQLClient>(s =>
             {
                 var platformEndpointOptions = s.GetRequiredService<IOptions<PlatformEndpointOptions>>().Value;

--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -342,6 +342,8 @@ namespace VirtoCommerce.Storefront
 
             services.AddProxy(builder => builder.AddHttpMessageHandler(sp => sp.GetService<AuthenticationHandlerFactory>().CreateAuthHandler()));
 
+            services.Configure<ProxyOptions>(options => options.WebSocketKeepAliveInterval = TimeSpan.FromSeconds(45));
+
             services.AddSingleton<IGraphQLClient>(s =>
             {
                 var platformEndpointOptions = s.GetRequiredService<IOptions<PlatformEndpointOptions>>().Value;

--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -342,8 +342,6 @@ namespace VirtoCommerce.Storefront
 
             services.AddProxy(builder => builder.AddHttpMessageHandler(sp => sp.GetService<AuthenticationHandlerFactory>().CreateAuthHandler()));
 
-            services.Configure<ProxyOptions>(options => options.WebSocketKeepAliveInterval = TimeSpan.FromSeconds(45));
-
             services.AddSingleton<IGraphQLClient>(s =>
             {
                 var platformEndpointOptions = s.GetRequiredService<IOptions<PlatformEndpointOptions>>().Value;


### PR DESCRIPTION
Description:
https://virtocommerce.atlassian.net/browse/VCST-473
* Adds proxy for XAPI subscription WebSocket connections same way as for other XAPI HTTP requests.
* Respect secure and insecure schemas (`http` -> `ws`, `https` -> `wss`)
* Sets default keep alive interval to 50 seconds (XAPI has 45 and it must be XAPI < storefront < theme)

--

QA-test: 

Demo-test: 

Download artifact URL: 
